### PR TITLE
fix: close browser context after authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export function combinePersonas<Personas extends Array<Persona<any, any>>>(
       if (fs.existsSync(sessionFilePath)) {
         const sessionFile = await readSessionFile(sessionFilePath)
 
-        // Perform session verification in a new, isolated context.
+        // Verify the session in a new, isolated browser context.
         const newContext = await browser.newContext({
           storageState: sessionFile,
         })
@@ -168,6 +168,9 @@ export function combinePersonas<Personas extends Array<Persona<any, any>>>(
               testInfo,
             )
             return createSession(persona)
+          })
+          .finally(async () => {
+            await newContext.close()
           })
       }
 


### PR DESCRIPTION
This fixes the issue when the browser context this library creates _persists_ in a form of a lone browser window while running the tests (e.g. in the debug mode). We never close that context so the browser window stays open, confusing the user. 

When the session is created, the library uses the same `page` as the user's test. There's no need to close it because that would ruin the test. 